### PR TITLE
TL/CUDA: Topology Cache (#1137)

### DIFF
--- a/src/components/tl/cuda/tl_cuda.c
+++ b/src/components/tl/cuda/tl_cuda.c
@@ -42,6 +42,11 @@ static ucc_config_field_t ucc_tl_cuda_lib_config_table[] = {
      "reduce_scatterv ring algorithms",
      ucc_offsetof(ucc_tl_cuda_lib_config_t, reduce_scatter_ring_max_rings),
      UCC_CONFIG_TYPE_ULUNITS},
+    
+    {"TOPO_CACHE_ENABLE", "y",
+     "Enable NVLINK topology cache",
+     ucc_offsetof(ucc_tl_cuda_lib_config_t, topo_cache_enable),
+     UCC_CONFIG_TYPE_BOOL},
 
     {NULL}};
 

--- a/src/components/tl/cuda/tl_cuda.h
+++ b/src/components/tl/cuda/tl_cuda.h
@@ -83,6 +83,7 @@ typedef struct ucc_tl_cuda_lib_config {
     unsigned long       allgather_ring_max_rings;
     uint32_t            allgather_ring_num_chunks;
     unsigned long       reduce_scatter_ring_max_rings;
+    uint32_t            topo_cache_enable;
 } ucc_tl_cuda_lib_config_t;
 
 typedef struct ucc_tl_cuda_context_config {
@@ -92,6 +93,7 @@ typedef struct ucc_tl_cuda_context_config {
 typedef struct ucc_tl_cuda_lib {
     ucc_tl_lib_t             super;
     ucc_tl_cuda_lib_config_t cfg;
+    ucc_tl_cuda_topo_t      *topo;  /* Shared topology information */
 } ucc_tl_cuda_lib_t;
 UCC_CLASS_DECLARE(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *,
                   const ucc_base_config_t *);

--- a/src/components/tl/cuda/tl_cuda_context.c
+++ b/src/components/tl/cuda/tl_cuda_context.c
@@ -11,12 +11,25 @@
 #include <cuda_runtime.h>
 #include <cuda.h>
 
+/**
+ * Initialize CUDA transport layer context
+ *
+ * This function initializes a CUDA TL context which requires an active CUDA context.
+ * It sets up memory pools for CUDA tasks and initializes the topology information.
+ *
+ * @param [in]  params      Base context initialization parameters
+ * @param [in]  config      Configuration for CUDA context
+ *
+ * @return UCC_OK on success or error code on failure
+ */
 UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
                     const ucc_base_context_params_t *params,
                     const ucc_base_config_t *config)
 {
     ucc_tl_cuda_context_config_t *tl_cuda_config =
         ucc_derived_of(config, ucc_tl_cuda_context_config_t);
+    ucc_tl_cuda_lib_t *lib =
+        ucc_derived_of(params->context->lib, ucc_tl_cuda_lib_t);
     ucc_status_t status;
     int num_devices;
     cudaError_t cuda_st;
@@ -29,8 +42,9 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
 
     cuda_st = cudaGetDeviceCount(&num_devices);
     if (cuda_st != cudaSuccess) {
-        tl_debug(self->super.super.lib, "failed to get number of GPU devices"
-                 "%d %s", cuda_st, cudaGetErrorName(cuda_st));
+        tl_debug(self->super.super.lib,
+                 "failed to get number of GPU devices: %d (%s)", cuda_st,
+                 cudaGetErrorName(cuda_st));
         return UCC_ERR_NO_RESOURCE;
     } else if (num_devices == 0) {
         tl_debug(self->super.super.lib, "no GPU devices found");
@@ -55,15 +69,35 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_context_t,
     }
 
     CUDA_CHECK_GOTO(cudaGetDevice(&self->device), free_mpool, status);
-    status = ucc_tl_cuda_topo_create(self->super.super.lib, &self->topo);
-    if (status != UCC_OK) {
-        tl_error(self->super.super.lib,
-                 "failed to initialize tl_cuda_topo");
-        goto free_mpool;
+
+    /* Handle CUDA topology initialization based on caching configuration */
+    if (lib->cfg.topo_cache_enable && lib->topo != NULL) {
+        /* If topology caching is enabled and a cached topology exists,
+           reuse the existing topology from the library */
+        self->topo = lib->topo;
+    } else {
+        /* Determine where to store the topology:
+           - If caching is enabled: store in lib->topo for reuse
+           - If caching is disabled: store in self->topo (context-specific) */
+        ucc_tl_cuda_topo_t **topo_ptr =
+            lib->cfg.topo_cache_enable ? &lib->topo : &self->topo;
+
+        /* Create new topology instance and store it in the appropriate location */
+        status = ucc_tl_cuda_topo_create((const ucc_base_lib_t *)&lib->super,
+                                         topo_ptr);
+        if (status != UCC_OK) {
+            tl_error(self->super.super.lib, "failed to initialize topology");
+            goto free_mpool;
+        }
+        /* Update the context's topology pointer to point to the newly created topology */
+        self->topo = *topo_ptr;
     }
+
     status = ucc_tl_cuda_topo_get_pci_id(self->device, &self->device_id);
     if (status != UCC_OK) {
-        tl_error(self->super.super.lib, "failed to get pci id");
+        tl_error(self->super.super.lib,
+                 "failed to get pci id for device %d, status: %s", self->device,
+                 ucc_status_string(status));
         goto free_mpool;
     }
 
@@ -94,10 +128,40 @@ ucc_status_t ucc_tl_cuda_memh_pack(const ucc_base_context_t *context, /* NOLINT 
     return UCC_ERR_NOT_IMPLEMENTED;
 }
 
+/**
+ * @brief Cleanup function for CUDA TL context
+ * 
+ * This function is responsible for cleaning up resources associated with a CUDA TL context.
+ * It performs the following operations:
+ * 1. Logs the context finalization with debug information
+ * 2. Destroys the IPC cache hash table if it exists
+ * 3. Cleans up topology if it's context-specific (not cached)
+ * 4. Cleans up the request memory pool
+ * 
+ * @param self Pointer to the CUDA TL context structure to be cleaned up
+ */
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_context_t)
 {
+    ucc_tl_cuda_lib_t *lib =
+        ucc_derived_of(self->super.super.lib, ucc_tl_cuda_lib_t);
+
+    // Log context finalization for debugging purposes
     tl_debug(self->super.super.lib, "finalizing tl context: %p", self);
-    ucc_tl_cuda_topo_destroy(self->topo);
+
+    // Clean up IPC cache if it exists
+    if (self->ipc_cache != NULL) {
+        kh_destroy(tl_cuda_ep_hash, self->ipc_cache);
+        self->ipc_cache = NULL;
+    }
+
+    // Only destroy topology if it's context-specific (not cached)
+    // For cached topology, it will be destroyed when the library is cleaned up
+    if (self->topo != NULL && !lib->cfg.topo_cache_enable) {
+        ucc_tl_cuda_topo_destroy(self->topo);
+        self->topo = NULL;
+    }
+
+    // Clean up the request memory pool with force leak check
     ucc_mpool_cleanup(&self->req_mp, 1);
 }
 

--- a/src/components/tl/cuda/tl_cuda_lib.c
+++ b/src/components/tl/cuda/tl_cuda_lib.c
@@ -32,12 +32,19 @@ UCC_CLASS_INIT_FUNC(ucc_tl_cuda_lib_t, const ucc_base_lib_params_t *params,
     if (self->cfg.scratch_size < min_scratch_size) {
         self->cfg.scratch_size = min_scratch_size;
     }
+
+    /* Initialize topology pointer to NULL - will be lazily initialized */
+    self->topo = NULL;
+
     tl_debug(&self->super, "initialized lib object: %p", self);
     return UCC_OK;
 }
 
 UCC_CLASS_CLEANUP_FUNC(ucc_tl_cuda_lib_t)
 {
+    if (self->topo) {
+        ucc_tl_cuda_topo_destroy(self->topo);
+    }
     tl_debug(&self->super, "finalizing lib object: %p", self);
 }
 


### PR DESCRIPTION
## What
  - Store topology in lib and reuse for context creation.
  - Fixed IPC cache leak. 
  - Improved logging. 
  - Added comments. 

  The topology information includes:
    - PCI device IDs
    - NVLink connections between GPUs
    - Device types (GPU or switch)
    - Link widths and counts

## Why ?
- Topology discovery is expensive (requires NVML calls)
- The topology rarely changes during runtime
- Multiple contexts can share the same topology information

## How ?

- When use_topo_cache is enabled (default):
  - The topology information is stored in `lib->topo` (library level)
- If a cached topology exists `(lib->topo != NULL)`, it is reused for new contexts
- If no cached topology exists, a new one is created and stored in lib->topo
- When use_topo_cache is disabled:
  - Each context gets its own topology instance stored in `self->topo`
  - No sharing/reuse of topology information between contexts

## What
_Describe what this PR is doing._ 

## Why ?
_Justification for the PR. If there is existing issue/bug please reference. For
bug fixes why and what can be merged in a single item._

## How ?
_It is optional but for complex PRs please provide information about the design,
architecture, approach, etc._
